### PR TITLE
Broken Monocle link and https mathjax

### DIFF
--- a/projects/monocle/index.html
+++ b/projects/monocle/index.html
@@ -96,7 +96,7 @@
 		<div class="pad-left note">
 			<div class="smallspacer"></div>
 			<i class="fa fa-cog fa-fw"></i>
-			<a class="off" href="http://https://cole-trapnell-lab.github.io/monocle-release/">Monocle</a>
+			<a class="off" href="https://cole-trapnell-lab.github.io/monocle-release/">Monocle</a>
 		</div>
         
         
@@ -263,7 +263,7 @@
 	    		
 	<!-- MathJax support -->
 	<script type="text/javascript"
-	 src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+	 src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 	<!-- MathJax config -->
 	<script src="/js/mathjax.config.js"></script>	
 			


### PR DESCRIPTION
Fix a broken link and use https for MathJax CDN.